### PR TITLE
🧹 [code health improvement] Move hardcoded Lock TTL to environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ SESSION_SECRET="replace-with-at-least-32-characters"
 
 # Storage provider: "local" (filesystem) — S3/R2 support planned
 STORAGE_PROVIDER="local"
+
+# TTL for tile locks in seconds (default: 90)
+LOCK_TTL_SECONDS=90

--- a/src/lib/lock-service.ts
+++ b/src/lib/lock-service.ts
@@ -2,7 +2,10 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "./prisma";
 import { createId } from "@paralleldrive/cuid2";
 
-const LOCK_TTL_SECONDS = 90;
+const LOCK_TTL_SECONDS = (() => {
+  const ttl = parseInt(process.env.LOCK_TTL_SECONDS ?? "90", 10);
+  return isNaN(ttl) ? 90 : ttl;
+})();
 
 export async function acquireLock(
   roomId: string,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Replaced the hardcoded magic number `LOCK_TTL_SECONDS = 90` with an environment variable configuration.

💡 **Why:** How this improves maintainability
- Moving this to an environment variable makes the system more flexible and easier to tune in different environments (dev, staging, prod) without requiring a redeploy or code change.

✅ **Verification:** How you confirmed the change is safe
- Verified the parsing logic with a standalone node script that tests default, custom, and invalid (NaN) cases.
- Logic: `const LOCK_TTL_SECONDS = (() => { const ttl = parseInt(process.env.LOCK_TTL_SECONDS ?? "90", 10); return isNaN(ttl) ? 90 : ttl; })();`
- Confirmed that the default behavior remains identical (90 seconds).

✨ **Result:** The improvement achieved
- The Lock TTL is now configurable via the `LOCK_TTL_SECONDS` environment variable, documented in `.env.example`.

---
*PR created automatically by Jules for task [7333758632878003891](https://jules.google.com/task/7333758632878003891) started by @kwrkb*