### PR TITLE
🔒 fix: prevent path traversal in reference image loading

### DIFF
--- a/src/lib/image-gen/dalle2-provider.test.ts
+++ b/src/lib/image-gen/dalle2-provider.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loadReferenceImage } from "./dalle2-provider";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(),
+}));
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe("loadReferenceImage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should throw an error for path traversal attempts with ..", async () => {
+    await expect(loadReferenceImage("../../etc/passwd")).rejects.toThrow("Invalid reference image URL");
+    await expect(loadReferenceImage("../package.json")).rejects.toThrow("Invalid reference image URL");
+  });
+
+  it("should throw an error for paths that resolve outside public", async () => {
+    await expect(loadReferenceImage("../../../etc/passwd")).rejects.toThrow("Invalid reference image URL");
+  });
+
+  it("should allow valid paths within the public directory", async () => {
+    const validUrl = "generated/test.png";
+    (readFileSync as any).mockReturnValue(Buffer.from("fake image data"));
+
+    await loadReferenceImage(validUrl);
+
+    expect(readFileSync).toHaveBeenCalledWith(expect.stringContaining(join("public", "generated", "test.png")));
+  });
+
+  it("should handle leading slashes correctly and safely", async () => {
+    const validUrl = "/generated/test.png";
+    (readFileSync as any).mockReturnValue(Buffer.from("fake image data"));
+
+    await loadReferenceImage(validUrl);
+
+    expect(readFileSync).toHaveBeenCalledWith(expect.stringContaining(join("public", "generated", "test.png")));
+  });
+
+  it("should handle absolute-looking paths by keeping them within public", async () => {
+    const url = "/etc/passwd"; // becomes etc/passwd relative to public
+    (readFileSync as any).mockReturnValue(Buffer.from("fake image data"));
+
+    await loadReferenceImage(url);
+
+    expect(readFileSync).toHaveBeenCalledWith(expect.stringContaining(join("public", "etc", "passwd")));
+  });
+});

--- a/src/lib/image-gen/dalle2-provider.ts
+++ b/src/lib/image-gen/dalle2-provider.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import { join } from "path";
+import { join, resolve, relative, isAbsolute } from "path";
 import { createId } from "@paralleldrive/cuid2";
 import { getStorageProvider } from "@/lib/storage";
 import OpenAI from "openai";
@@ -25,14 +25,22 @@ async function sleep(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function loadReferenceImage(imageUrl: string): Promise<Buffer> {
+export async function loadReferenceImage(imageUrl: string): Promise<Buffer> {
   if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
     const res = await fetch(imageUrl);
     if (!res.ok) throw new Error(`Failed to fetch reference image: ${res.status}`);
     return Buffer.from(await res.arrayBuffer());
   }
   const trimmed = imageUrl.startsWith("/") ? imageUrl.slice(1) : imageUrl;
-  return readFileSync(join(process.cwd(), "public", trimmed));
+  const publicDir = join(process.cwd(), "public");
+  const targetPath = resolve(publicDir, trimmed);
+
+  const rel = relative(publicDir, targetPath);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error("Invalid reference image URL");
+  }
+
+  return readFileSync(targetPath);
 }
 
 function createMaskBuffer(size: number, direction: Direction): Buffer {


### PR DESCRIPTION
Fixed a path traversal vulnerability in `src/lib/image-gen/dalle2-provider.ts` by validating that requested image paths remain within the `public` directory. Added unit tests to ensure future regressions are caught.

---
*PR created automatically by Jules for task [2969994291180200988](https://jules.google.com/task/2969994291180200988) started by @kwrkb*