### PR TITLE
⚡ Optimize re-renders with useCallback and React.memo

### DIFF
--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, use } from "react";
+import { useState, useEffect, useRef, use, useCallback } from "react";
 import Link from "next/link";
 import { useUser } from "@/hooks/use-user";
 import { useRoom } from "@/hooks/use-room";
@@ -98,11 +98,11 @@ export default function RoomPage({ params }: RoomPageProps) {
     }
   }, [isOwner, room.initialTileStatus, room.initialPrompt, roomId]);
 
-  function handleExpand(x: number, y: number, fromTile: Tile) {
+  const handleExpand = useCallback((x: number, y: number, fromTile: Tile) => {
     setExpandTarget({ x, y, fromTile });
-  }
+  }, []);
 
-  async function handleAdopt(expansion: Expansion) {
+  const handleAdopt = useCallback(async (expansion: Expansion) => {
     try {
       const res = await fetch(`/api/expansions/${expansion.id}/adopt`, {
         method: "POST",
@@ -119,9 +119,9 @@ export default function RoomPage({ params }: RoomPageProps) {
     } catch {
       addToast("ネットワークエラー", "error");
     }
-  }
+  }, [addToast, refetch]);
 
-  async function handleRetryInitial() {
+  const handleRetryInitial = useCallback(async () => {
     try {
       const res = await fetch(`/api/rooms/${roomId}/generate-initial`, {
         method: "POST",
@@ -136,9 +136,9 @@ export default function RoomPage({ params }: RoomPageProps) {
     } catch {
       addToast("ネットワークエラー", "error");
     }
-  }
+  }, [roomId, addToast, refetch]);
 
-  async function handleReject(expansion: Expansion) {
+  const handleReject = useCallback(async (expansion: Expansion) => {
     try {
       const res = await fetch(`/api/expansions/${expansion.id}/reject`, {
         method: "POST",
@@ -155,7 +155,7 @@ export default function RoomPage({ params }: RoomPageProps) {
     } catch {
       addToast("ネットワークエラー", "error");
     }
-  }
+  }, [addToast, refetch]);
 
   return (
     <div className="h-screen flex flex-col" style={{ background: "var(--color-surface-0)" }}>

--- a/src/components/canvas/tile-cell.tsx
+++ b/src/components/canvas/tile-cell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import Image from "next/image";
 import type { Tile, Expansion, Lock } from "@/types";
 
@@ -23,7 +24,7 @@ interface TileCellProps {
   onRetryInitial?: () => void;
 }
 
-export function TileCell({
+export const TileCell = memo(function TileCell({
   x,
   y,
   tile,
@@ -260,4 +261,4 @@ export function TileCell({
       }}
     />
   );
-}
+});

--- a/src/components/canvas/tile-grid.tsx
+++ b/src/components/canvas/tile-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useCallback, useEffect, useMemo } from "react";
+import { useRef, useState, useCallback, useEffect, useMemo, memo } from "react";
 import type { RoomDetail, Tile, Expansion, Lock, InitialTileStatus } from "@/types";
 import { TileCell } from "./tile-cell";
 
@@ -66,7 +66,7 @@ function getAdjacentTile(
   return undefined;
 }
 
-export function TileGrid({
+export const TileGrid = memo(function TileGrid({
   room,
   userId,
   isOwner,
@@ -352,4 +352,4 @@ export function TileGrid({
       </div>
     </div>
   );
-}
+});

--- a/src/components/expansion/candidate-list.tsx
+++ b/src/components/expansion/candidate-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import Image from "next/image";
 import type { Expansion } from "@/types";
 
@@ -19,7 +20,7 @@ const STATUS_LABELS: Record<string, string> = {
   ADOPTED: "採用済",
 };
 
-export function CandidateList({
+export const CandidateList = memo(function CandidateList({
   expansions,
   isOwner,
   onAdopt,
@@ -121,4 +122,4 @@ export function CandidateList({
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
💡 **What:**
Wrapped event handlers (`handleExpand`, `handleAdopt`, `handleRetryInitial`, `handleReject`) in `useCallback` in `src/app/room/[id]/page.tsx` and applied `React.memo` to `TileGrid`, `TileCell`, and `CandidateList` components.

🎯 **Why:**
These components are part of a grid-like UI that re-renders frequently (due to 3s polling of the room state). Stabilizing callback references and using memoization prevents expensive re-renders of the entire grid and its cells when only the room data is updated but other props remain the same.

📊 **Measured Improvement:**
While a quantitative baseline could not be established in this environment due to the lack of profiling tools and a running dev server, this is a standard React performance optimization. By ensuring stable references for callbacks passed to child components, we enable `React.memo` to skip re-renders, significantly reducing CPU usage during state updates (polling). For a large grid of `TileCell`s, this prevents O(N) re-render overhead on every poll.

---
*PR created automatically by Jules for task [16483964401284193381](https://jules.google.com/task/16483964401284193381) started by @kwrkb*