### PR TITLE
fix: stale session による FK 制約エラー (P2003) を修正

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -66,13 +66,17 @@
   - [x] dalle2-provider: `executeWithRetry` にリトライ+DL+アップロードを共通化
 
 ### Steps（シームレスタイル接続）
-- [ ] 隣接タイルコンテキストによるシームレス画像生成
-  - [ ] `provider.ts`: `GenerateInput` に `adjacentImages` フィールド追加
-  - [ ] `run/route.ts`: ターゲットセルの上下左右タイルを DB から取得
-  - [ ] `dalle2-provider.ts`: 512x512 コンポジットキャンバス + エッジストリップ + クロップ
-  - [ ] `route.test.ts`: `tile.findMany` モック追加 + 隣接タイルテスト追加
+- [completed] 隣接タイルコンテキストによるシームレス画像生成 (PR #20)
+  - [x] `provider.ts`: `GenerateInput` に `adjacentImages` フィールド追加
+  - [x] `run/route.ts`: ターゲットセルの上下左右タイルを DB から取得
+  - [x] `dalle2-provider.ts`: 512x512 コンポジットキャンバス + エッジストリップ + クロップ
+  - [x] `route.test.ts`: `tile.findMany` モック追加 + adjacentImages マッピング簡素化
+
+### Steps（Stale Session 修正）
+- [ ] `auth.ts`: `getUserIdFromSession` に DB 存在チェック追加（FK 制約エラー P2003 修正）
 
 ### Notes
+- 2026-02-24: PR #20 マージ。シームレスタイル接続（コンポジットキャンバス方式）を実装。Stale session による FK 制約エラー (P2003) を発見、`auth.ts` の DB 存在チェック追加を次タスクとする。
 - 2026-02-23: UI/UX Phase 3 を完了。`tile-cell` にフレーム効果を追加し、拡張セルをパルス演出＋アイコン強化で再設計。`candidate-list` はタブ化（進行中/採用待ち/履歴）とステータスフィルタを実装。
 - 2026-02-23: `lucide-react` / `framer-motion` をインストールし、UI/UX Phase 2 を完了。主要コンポーネントのアイコンを Lucide に置換し、Framer Motion による滑らかなアニメーションを導入。
 - 2026-02-23: PR #17（missing hooks 復元 + path traversal 修正）をマージ後、PR #16 のレビュー指摘対応を実施。未定義CSS変数の追加、dark:ハードコード除去、日英混在テキストの日本語統一、AnimatePresence 統合、ホバーボーダー復元、スコープ外 GEMINI.md の除外。

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,15 @@
 import type { NextRequest } from "next/server";
+import { prisma } from "./prisma";
 import { getSession } from "./session";
 
 export async function getUserIdFromSession(req: NextRequest): Promise<string | null> {
   const session = await getSession(req);
-  return session?.userId ?? null;
+  const userId = session?.userId ?? null;
+  if (!userId) return null;
+
+  // DB にユーザーが存在するか確認（stale session 対策）
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { id: true } });
+  if (!user) return null;
+
+  return userId;
 }


### PR DESCRIPTION
## Summary

- `getUserIdFromSession` に `prisma.user.findUnique` による DB 存在チェックを追加
- DB リセット後に iron-session cookie (14日TTL) が残存していた場合、`lock.create` で P2003 (Foreign key constraint) が発生していた問題を修正
- User が DB に存在しない場合は `null` を返し、全 API エンドポイントで 401 を返す

## Test plan

- [ ] `npx tsc --noEmit` — 型エラーなし
- [ ] `npm test` — 全13件通過（既存テストは `getUserIdFromSession` をモックしているため影響なし）
- [ ] DB リセット後、古い cookie のままロック取得 → 401 が返ることを確認
- [ ] 再ログイン後にロック取得 → 正常動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)