### PR TITLE
fix: #21 run/route.ts の認可チェック不足を修正

### DIFF
--- a/src/app/api/expansions/[id]/run/route.test.ts
+++ b/src/app/api/expansions/[id]/run/route.test.ts
@@ -8,9 +8,6 @@ type PrismaMock = {
     findUnique: FnMock;
     update: FnMock;
   };
-  room: {
-    findUnique: FnMock;
-  };
   tile: {
     findUnique: FnMock;
     findMany: FnMock;
@@ -26,9 +23,6 @@ vi.mock("@/lib/prisma", () => ({
     expansion: {
       findUnique: vi.fn(),
       update: vi.fn(),
-    },
-    room: {
-      findUnique: vi.fn(),
     },
     tile: {
       findUnique: vi.fn(),
@@ -95,6 +89,7 @@ describe("POST /api/expansions/:id/run", () => {
       targetX: 1,
       targetY: 0,
       createdByUserId: "user-1",
+      room: { ownerUserId: "user-1" },
     });
     prismaMock.tile.findUnique.mockResolvedValue({
       id: "tile-1",
@@ -143,6 +138,7 @@ describe("POST /api/expansions/:id/run", () => {
       targetX: 1,
       targetY: 0,
       createdByUserId: "user-1",
+      room: { ownerUserId: "user-1" },
     });
     prismaMock.tile.findUnique.mockResolvedValue({
       id: "tile-1",
@@ -181,10 +177,7 @@ describe("POST /api/expansions/:id/run", () => {
       targetX: 1,
       targetY: 0,
       createdByUserId: "user-other",
-    });
-    prismaMock.room.findUnique.mockResolvedValue({
-      id: "room-1",
-      ownerUserId: "user-owner",
+      room: { ownerUserId: "user-owner" },
     });
 
     const { POST } = await import("./route");
@@ -217,10 +210,7 @@ describe("POST /api/expansions/:id/run", () => {
       targetX: 1,
       targetY: 0,
       createdByUserId: "user-other",
-    });
-    prismaMock.room.findUnique.mockResolvedValue({
-      id: "room-1",
-      ownerUserId: "user-1",
+      room: { ownerUserId: "user-1" },
     });
     prismaMock.tile.findUnique.mockResolvedValue({
       id: "tile-1",


### PR DESCRIPTION
## Summary
- `POST /api/expansions/:id/run` にexpansion作成者またはルームオーナーの認可チェックを追加
- 未認可ユーザーには403 Forbiddenを返却
- テストケース2件追加（別ユーザー→403拒否、ルームオーナー→許可）

## Test plan
- [x] 既存テスト全パス（5/5）
- [x] 型チェック通過
- [ ] expansion作成者でないユーザーがrunを叩いた場合に403が返ることを手動確認
- [ ] ルームオーナーが他ユーザーのexpansionをrunできることを手動確認

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)