### PR TITLE
🧪 Add unit tests for SSE Emitter

### DIFF
--- a/src/lib/sse-emitter.test.ts
+++ b/src/lib/sse-emitter.test.ts
@@ -1,13 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { emitRoomEvent, onRoomEvent } from './sse-emitter';
 
 describe('sse-emitter', () => {
+  const cleanups: (() => void)[] = [];
+
+  afterEach(() => {
+    cleanups.forEach((fn) => fn());
+    cleanups.length = 0;
+  });
+
   it('should call the listener when a room event is emitted', () => {
     const roomId = 'room-1';
     const eventName = 'update';
     const listener = vi.fn();
 
-    onRoomEvent(roomId, listener);
+    cleanups.push(onRoomEvent(roomId, listener));
     emitRoomEvent(roomId, eventName);
 
     expect(listener).toHaveBeenCalledWith(eventName);
@@ -19,8 +26,8 @@ describe('sse-emitter', () => {
     const listener1 = vi.fn();
     const listener2 = vi.fn();
 
-    onRoomEvent(roomId, listener1);
-    onRoomEvent(roomId, listener2);
+    cleanups.push(onRoomEvent(roomId, listener1));
+    cleanups.push(onRoomEvent(roomId, listener2));
     emitRoomEvent(roomId, eventName);
 
     expect(listener1).toHaveBeenCalledWith(eventName);
@@ -33,7 +40,7 @@ describe('sse-emitter', () => {
     const eventName = 'update';
     const listener = vi.fn();
 
-    onRoomEvent(roomId1, listener);
+    cleanups.push(onRoomEvent(roomId1, listener));
     emitRoomEvent(roomId2, eventName);
 
     expect(listener).not.toHaveBeenCalled();


### PR DESCRIPTION
The testing gap for `src/lib/sse-emitter.ts` was addressed by adding a new test file `src/lib/sse-emitter.test.ts`.

Scenarios covered:
- Basic event emission and listener notification.
- Multiple listeners for the same room.
- Proper scoping of events (room isolation).
- Correct cleanup when unregistering a listener.

Tests were verified to pass using `bun test` and failed correctly when a bug was introduced.

---
*PR created automatically by Jules for task [4489972571037652304](https://jules.google.com/task/4489972571037652304) started by @kwrkb*