### PR TITLE
🔒 Add authentication to Room Details and Events endpoints

### DIFF
--- a/src/app/api/rooms/[id]/events/route.ts
+++ b/src/app/api/rooms/[id]/events/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from "next/server";
 import { onRoomEvent } from "@/lib/sse-emitter";
+import { getUserIdFromSession } from "@/lib/auth";
+import { unauthorized } from "@/lib/errors";
 
 export const dynamic = "force-dynamic";
 
@@ -11,6 +13,9 @@ export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const userId = await getUserIdFromSession(req);
+  if (!userId) return unauthorized("Login required");
+
   const { id: roomId } = await params;
   const encoder = new TextEncoder();
 

--- a/src/app/api/rooms/[id]/route.test.ts
+++ b/src/app/api/rooms/[id]/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+type FnMock = ReturnType<typeof vi.fn>;
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    room: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getUserIdFromSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auto-adopt", () => ({
+  autoAdoptStaleExpansions: vi.fn(),
+}));
+
+async function getMocks() {
+  const [prismaModule, authModule] = await Promise.all([
+    import("@/lib/prisma"),
+    import("@/lib/auth"),
+  ]);
+
+  return {
+    prismaMock: prismaModule.prisma as any,
+    getUserIdFromSessionMock: vi.mocked(authModule.getUserIdFromSession) as unknown as FnMock,
+  };
+}
+
+describe("GET /api/rooms/:id", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no authenticated session exists", async () => {
+    const { getUserIdFromSessionMock } = await getMocks();
+    getUserIdFromSessionMock.mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const req = new NextRequest("http://localhost/api/rooms/room-1");
+
+    const res = await GET(req, { params: Promise.resolve({ id: "room-1" }) });
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Login required");
+  });
+
+  it("returns 200 when authenticated", async () => {
+    const { getUserIdFromSessionMock, prismaMock } = await getMocks();
+    getUserIdFromSessionMock.mockResolvedValue("user-1");
+    prismaMock.room.findUnique.mockResolvedValue({
+      id: "room-1",
+      expansions: [],
+    });
+
+    const { GET } = await import("./route");
+    const req = new NextRequest("http://localhost/api/rooms/room-1");
+
+    const res = await GET(req, { params: Promise.resolve({ id: "room-1" }) });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/rooms/[id]/route.ts
+++ b/src/app/api/rooms/[id]/route.ts
@@ -1,13 +1,17 @@
 import { after } from "next/server";
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { notFound } from "@/lib/errors";
+import { notFound, unauthorized } from "@/lib/errors";
 import { autoAdoptStaleExpansions } from "@/lib/auto-adopt";
+import { getUserIdFromSession } from "@/lib/auth";
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const userId = await getUserIdFromSession(req);
+  if (!userId) return unauthorized("Login required");
+
   const { id } = await params;
 
   const now = new Date();


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the lack of authentication and authorization on the Room Details GET endpoint (`/api/rooms/[id]`) and its corresponding SSE events endpoint.
⚠️ **Risk:** Without this fix, any unauthenticated user could access sensitive room data, including tiles, expansions, and active locks, potentially leading to information disclosure.
🛡️ **Solution:** Added `getUserIdFromSession(req)` checks to both `src/app/api/rooms/[id]/route.ts` and `src/app/api/rooms/[id]/events/route.ts`. Requests without a valid session will now receive a `401 Unauthorized` response. Also added a unit test to verify the fix.

---
*PR created automatically by Jules for task [9729405431788682234](https://jules.google.com/task/9729405431788682234) started by @kwrkb*