### PR TITLE
fix: loadReferenceImage と mockGenerate の readFileSync を非同期化 (closes #22)

### DIFF
--- a/src/lib/image-gen/dalle2-provider.test.ts
+++ b/src/lib/image-gen/dalle2-provider.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { loadReferenceImage } from "./dalle2-provider";
-import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
 import { join } from "path";
 
-vi.mock("fs");
+vi.mock("fs/promises");
 
 // Mock global fetch
 global.fetch = vi.fn();
@@ -30,28 +30,28 @@ describe("loadReferenceImage", () => {
 
   it("should allow valid paths within the public directory", async () => {
     const validUrl = "generated/test.png";
-    vi.mocked(readFileSync).mockReturnValue(Buffer.from("fake image data"));
+    vi.mocked(readFile).mockResolvedValue(Buffer.from("fake image data"));
 
     await loadReferenceImage(validUrl);
 
-    expect(readFileSync).toHaveBeenCalledWith(expect.stringContaining(join("public", "generated", "test.png")));
+    expect(readFile).toHaveBeenCalledWith(expect.stringContaining(join("public", "generated", "test.png")));
   });
 
   it("should handle leading slashes correctly and safely", async () => {
     const validUrl = "/generated/test.png";
-    vi.mocked(readFileSync).mockReturnValue(Buffer.from("fake image data"));
+    vi.mocked(readFile).mockResolvedValue(Buffer.from("fake image data"));
 
     await loadReferenceImage(validUrl);
 
-    expect(readFileSync).toHaveBeenCalledWith(expect.stringContaining(join("public", "generated", "test.png")));
+    expect(readFile).toHaveBeenCalledWith(expect.stringContaining(join("public", "generated", "test.png")));
   });
 
   it("should handle absolute-looking paths by keeping them within public", async () => {
     const url = "/etc/passwd"; // becomes etc/passwd relative to public
-    vi.mocked(readFileSync).mockReturnValue(Buffer.from("fake image data"));
+    vi.mocked(readFile).mockResolvedValue(Buffer.from("fake image data"));
 
     await loadReferenceImage(url);
 
-    expect(readFileSync).toHaveBeenCalledWith(expect.stringContaining(join("public", "etc", "passwd")));
+    expect(readFile).toHaveBeenCalledWith(expect.stringContaining(join("public", "etc", "passwd")));
   });
 });

--- a/src/lib/image-gen/dalle2-provider.ts
+++ b/src/lib/image-gen/dalle2-provider.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
 import { join, resolve, relative, isAbsolute } from "path";
 import { createId } from "@paralleldrive/cuid2";
 import { getStorageProvider } from "@/lib/storage";
@@ -43,7 +43,7 @@ export async function loadReferenceImage(imageUrl: string): Promise<Buffer> {
     throw new Error("Invalid reference image URL");
   }
 
-  return readFileSync(targetPath);
+  return readFile(targetPath);
 }
 
 function createMaskBuffer(size: number, direction: Direction): Buffer {

--- a/src/lib/image-gen/mock-provider.ts
+++ b/src/lib/image-gen/mock-provider.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
 import { join } from "path";
 import { createId } from "@paralleldrive/cuid2";
 import { getStorageProvider } from "@/lib/storage";
@@ -12,7 +12,7 @@ export class MockImageGenProvider implements ImageGenProvider {
 
     const filename = `${createId()}.png`;
     const srcPath = join(process.cwd(), "public", "placeholder.png");
-    const buffer = readFileSync(srcPath);
+    const buffer = await readFile(srcPath);
 
     const storage = getStorageProvider();
     const imagePath = await storage.upload(buffer, filename);


### PR DESCRIPTION
## Summary
- `loadReferenceImage` (`dalle2-provider.ts`) と `mockGenerate` (`mock-provider.ts`) は async 関数でありながら同期 `readFileSync` を呼び出しており、API route ハンドラのホットパスでイベントループをブロックしていた
- `fs/promises.readFile` への置換で解消（既に `src/lib/storage/local-provider.ts` で使われているパターンに揃える）
- テストも `vi.mock("fs/promises")` に切替、`mockReturnValue` → `mockResolvedValue`

呼び出し側は全て `await` 済みのため cascade 無し。

## Test plan
- [x] `npx vitest run src/lib/image-gen` — 既存6テスト全通過
- [x] `npx vitest run` — 全 22 テスト通過
- [x] `npx tsc --noEmit` — 型エラーなし

closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
